### PR TITLE
Update some deps, remove some unused deps.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,29 +9,26 @@ license = "MIT"
 [dependencies]
 serde = "1.0"
 serde_derive = "1.0"
-reqwest = { version = "0.10" }  # TODO: use json feature and refact
-hyper = "0.11"
-http = "0.2"
+reqwest = { version = "0.11" }  # TODO: use json feature and refact
 chrono = "0.4"
 rust-crypto = "0.2"
 hmac = "0.4"
 sha2 = "0.6"
-base64 = "0.6"
+base64 = "0.13"
 rustc-serialize = "0.3"
 hmac-sha1 = "0.1"
 url = "2.1"
 log = "0.4"
-md5 = "0.3"
+md5 = "0.7"
 serde_json = "1.0"
-regex = "0.2"
-quick-xml = "0.12"
-colored = "1.6"
+regex = "1"
+quick-xml = "0.22"
 failure = "0.1"
 failure_derive ="0.1"
 mime_guess = "2.0"
 async-trait = { version = "0.1", optional = true }
-tokio = { version = "0.2", optional = true }
-bytes = { version= "0.5", optional = true }
+tokio = { version = "1", optional = true }
+bytes = { version= "1", optional = true }
 dyn-clone = "1.0"
 futures = "0.3.12"
 
@@ -42,7 +39,7 @@ blocking = [
 ]
 "tokio-async" = [
     "async-trait",
-    "tokio/fs", "tokio/macros", "tokio/rt-threaded",
+    "tokio/fs", "tokio/macros", "tokio/rt-multi-thread",
     "bytes",
 ]
 # "std-async" = []


### PR DESCRIPTION
I noticed that a lot of outdated libraries were being brought into the nushell build via this crate, so this starts to update things to clean that up. (There's still more that can be updated or removed, but that requires code changes.)