### PR TITLE
remove rust-crypto dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ serde = "1.0"
 serde_derive = "1.0"
 reqwest = { version = "0.11" }  # TODO: use json feature and refact
 chrono = "0.4"
-rust-crypto = "0.2"
 hmac = "0.11"
 sha2 = "0.9"
 base64 = "0.13"
@@ -31,6 +30,7 @@ tokio = { version = "1", optional = true }
 bytes = { version= "1", optional = true }
 dyn-clone = "1.0"
 futures = "0.3.12"
+hex = "0.4.3"
 
 [features]
 default = [ "blocking", "tokio-async" ]


### PR DESCRIPTION
The last update of `rust-crypto` was `0.2.36 May 20, 2016`
I migrated the use of `rust-crypto::Sha256` to `sha2::Sha256`.
This results in the projects depending on this crate, no longer pulling in old or semver-incompatible versions of crates because of rust-crypto.
I ran `cargo test` and everything still passed. 
I hope I didn't miss or break anything.
If no breaking changes occurred since the last release of this crate `version = "0.7.4"`, is there a chance that a new patch-release `version = "0.7.5"` can occur in the near future?